### PR TITLE
Add a new roadmap about software design and architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Please read [contribution guidelines](contributing.md), thank you!
 - [Deep Learning Papers Reading Roadmap](https://github.com/floodsung/Deep-Learning-Papers-Reading-Roadmap) - Deep Learning papers reading roadmap for anyone who are eager to learn this amazing tech.
 - [Data Scientist Roadmap](https://github.com/hasbrain/data-science-roadmap) - Gives you an overview of the core skills needed in data science.
 - [Hacker Roadmap](https://github.com/Sundowndev/hacker-roadmap) - A guide for amateurs pen testers and a collection of hacking tools, resources and references.
+- [The Full-Stack Software Design and Architecture Roadmap](https://github.com/stemmlerjs/software-design-and-architecture-roadmap) - A software design and architecture roadmap for any developer.
 
 ## Articles
 - [A Roadmap To Become A Better Android Developer](https://medium.com/mindorks/a-roadmap-to-become-a-better-android-developer-3038cf7f8c8d) - A collection of articles to provide a proper roadmap to become a better Android Developer.


### PR DESCRIPTION
Hi ! 👋 

I would like to add a link to a cool roadmap I recently read on [dev.to](https://dev.to/stemmlerjs/how-to-learn-software-design-and-architecture-ago). Is it possible ?

Thanks !